### PR TITLE
Add spaces to privacy-policy.md

### DIFF
--- a/docs/privacy-policy.md
+++ b/docs/privacy-policy.md
@@ -1,10 +1,10 @@
 Privacy policy for Fintunes
 
-Fintunes does not collect any personal data. Period. We respect your right to
+Fintunes does not collect any personal data. Period. We respect your right to 
 autonomy and vow to not collect any information without user consent at all.
 
-If you opt-in to crash logging, we will collect analytics data from your device,
-every time a crash occurs. This data includes debugging information such as
-devices, versions and the specific error. All data is sent to a server
-controlled by the first party. No third parties can access this data in any
+If you opt-in to crash logging, we will collect analytics data from your device, 
+every time a crash occurs. This data includes debugging information such as 
+devices, versions and the specific error. All data is sent to a server 
+controlled by the first party. No third parties can access this data in any 
 form. No personal data is included in the analytics data.


### PR DESCRIPTION
In the privacy policy, some spaces are missing.

Since you import the text file in docs/privacy-policy.md, add some space to the end of the lines to prevent words missing a space.

See screenshot:

![Screenshot_20240401-141838_Fintunes](https://github.com/leinelissen/jellyfin-audio-player/assets/36538123/b7e49d94-6066-4e1d-9371-3f8fc7d0dfa1)
