### PR TITLE
Android: add edge-to-edge support

### DIFF
--- a/android/app/src/main/java/com/jellyfinaudioplayer/MainActivity.kt
+++ b/android/app/src/main/java/com/jellyfinaudioplayer/MainActivity.kt
@@ -5,7 +5,8 @@ import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
 
-import android.os.Bundle;
+import android.os.Bundle
+import androidx.core.view.WindowCompat
 
 class MainActivity : ReactActivity() {
 
@@ -24,5 +25,6 @@ class MainActivity : ReactActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(null)
+    WindowCompat.setDecorFitsSystemWindows(window, false)
   }
 }

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -3,6 +3,8 @@
     <style name="AppTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Customize your theme here. -->
         <!-- <item name="android:textColor">#000000</item> -->
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>
 
 </resources>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -13,6 +13,7 @@ import { ColorSchemeProvider, themes, useUserOrSystemScheme } from './Colors';
 import DownloadManager from './DownloadManager';
 import AppLoading from './AppLoading';
 import { captureException } from '@sentry/react-native';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
 
 const LightTheme = {
     ...DefaultTheme,
@@ -88,12 +89,14 @@ export default function App(): JSX.Element | null {
     return (
         <Provider store={store}>
             <PersistGate loading={null} persistor={persistedStore}>
-                <ColorSchemeProvider>
-                    <ThemedNavigationContainer>
-                        <Routes />
-                        <DownloadManager />
-                    </ThemedNavigationContainer>
-                </ColorSchemeProvider>
+                <SafeAreaProvider>
+                    <ColorSchemeProvider>
+                        <ThemedNavigationContainer>
+                            <Routes />
+                            <DownloadManager />
+                        </ThemedNavigationContainer>
+                    </ColorSchemeProvider>
+                </SafeAreaProvider>
             </PersistGate>
         </Provider>
     );


### PR DESCRIPTION
Add edge-to-edge support to fix the overlapping windows on devices with cutout. Fixes #305.