### PR TITLE
Enable zh-Hant translations

### DIFF
--- a/src/localisation/index.ts
+++ b/src/localisation/index.ts
@@ -19,6 +19,8 @@ const localeGetters: Record<string, () => object> = {
     sv: () => require('./lang/sv/locale.json'),
     uk: () => require('./lang/uk/locale.json'),
     zh: () => require('./lang/zh/locale.json'),
+    'zh-Hant': () => require('./lang/zh_Hant/locale.json'),
+    'zh-TW': () => require('./lang/zh_Hant/locale.json'),
 };
 
 // Have RNLocalize pick the best locale from the languages on offer


### PR DESCRIPTION
Weblate shows that the zh-Hant translations is already 98% complete. And as a Traditional Chinese user I can also say the translation shows acceptable quality.

We should enable these translations, otherwise users with zh-Hant locale will be shown Simplified Chinese (zh).