### PR TITLE
Enable Bulgarian translations

### DIFF
--- a/src/localisation/index.ts
+++ b/src/localisation/index.ts
@@ -6,6 +6,7 @@ const i18n = new I18n();
 
 // Lazy loaders for locale
 const localeGetters: Record<string, () => object> = {
+    bg: () => require('./lang/bg/locale.json'),
     de: () => require('./lang/de/locale.json'),
     en: () => require('./lang/en/locale.json'),
     es: () => require('./lang/es/locale.json'),


### PR DESCRIPTION
It turns out the Bulgarian translation were not enabled before, while they were almost 100% ready.