### PR TITLE
docs: fix typos in README build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ You will need to setup your Jellyfin account for the application to be able to p
 
 ## Building from source
 ### Prerequisites
-This project is built on React Native, and first of all requires [NodeJS](https://nodejs.org/en/) and PNPM to be installed. After installing it and cloning this repository, don't forget ton run `pnpm install` on your command line, so that all Node dependencies are installed.
+This project is built on React Native, and first of all requires [NodeJS](https://nodejs.org/en/) and PNPM to be installed. After installing it and cloning this repository, don't forget to run `pnpm install` on your command line, so that all Node dependencies are installed.
 
 #### iOS Prerequisites
-[XCode](https://developer.apple.com/download/) is required to build the iOS application. It also comes bundles with iOS simulators which make development exceedingly easy. This does mean that iOS development is limited to macs.
+[XCode](https://developer.apple.com/download/) is required to build the iOS application. It also comes bundled with iOS simulators which make development exceedingly easy. This does mean that iOS development is limited to macs.
 
 #### Android prerequisites
-[Android Studio](https://developer.android.com/studio/install) is recommended for development as it includes the Android SDK as well as Android Simulators for devleopment. At the very least, installing the Android SDK is neccessary for building any version of the app.
+[Android Studio](https://developer.android.com/studio/install) is recommended for development as it includes the Android SDK as well as Android Simulators for development. At the very least, installing the Android SDK is necessary for building any version of the app.
 
 ### Development Build
 As soon as all prerequisites are covered, you can start development in either iOS or Android simulators by running the following


### PR DESCRIPTION
## Summary
- Fix a few small typos in the README's build-from-source instructions:
  - "ton run" → "to run"
  - "comes bundles with" → "comes bundled with"
  - "devleopment" → "development"
  - "neccessary" → "necessary"

This is my first open source contribution, so I kept it small and focused on doc accuracy only — no functional changes.

## Test plan
- N/A (documentation-only change)